### PR TITLE
Relation traversal and propagation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Removed
 - `tcod.ecs.query.Query` removed due to a refactor.
+- `abstract_component` decorator removed.
 
 ### Fixed
 - Fix for `x in Entity.relation_tags_many` not checking the correct values.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Added the `tcod.ecs.IsA` sentinel value.
+- Entities will automatically inherit components/tags/relations from entities they have an `IsA` relationship with. https://github.com/HexDecimal/python-tcod-ecs/pull/15
+- Entities can be used as prefabs, use `Entity.instantiate()` to make a new entities inheriting the base entities components/tags/relations.
+
 ### Removed
 - `tcod.ecs.query.Query` removed due to a refactor.
+
+### Fixed
+- Fix for `x in Entity.relation_tags_many` not checking the correct values.
 
 ## [4.4.0] - 2023-08-11
 ### Added

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -27,6 +27,11 @@ API reference
    :undoc-members:
    :show-inheritance:
 
+.. automodule:: tcod.ecs.constants
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
 .. automodule:: tcod.ecs.typing
    :members:
    :undoc-members:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,12 @@ classifiers = [
 ]
 dynamic = ["version", "description"]
 requires-python = ">=3.8"
-dependencies = ["typing-extensions >=4.4.0", "attrs>=23.1.0", "cattrs>=23.1.2"]
+dependencies = [
+    "attrs >=23.1.0",
+    "cattrs >=23.1.2",
+    "sentinel-value >=1.0.0",
+    "typing-extensions >=4.4.0",
+]
 
 [tool.setuptools_scm]
 write_to = "tcod/ecs/_version.py"

--- a/tcod/ecs/__init__.py
+++ b/tcod/ecs/__init__.py
@@ -2,7 +2,6 @@
 from __future__ import annotations
 
 import importlib.metadata
-import warnings
 from collections import defaultdict
 from typing import TypeVar
 
@@ -15,7 +14,6 @@ __all__ = (
     "Entity",
     "IsA",
     "World",
-    "abstract_component",
 )
 
 try:
@@ -24,25 +22,9 @@ except importlib.metadata.PackageNotFoundError:
     __version__ = ""
 
 
-T = TypeVar("T")
 _T1 = TypeVar("_T1")
 _T2 = TypeVar("_T2")
 _T3 = TypeVar("_T3")
-
-
-def abstract_component(cls: type[T]) -> type[T]:
-    """Register class `cls` as an abstract component and return it.
-
-    .. deprecated:: 3.1
-        This decorator is deprecated since abstract components should always be explicit.
-    """
-    warnings.warn(
-        "This decorator is deprecated since abstract components should always be explicit.",
-        FutureWarning,
-        stacklevel=2,
-    )
-    cls._TCOD_BASE_COMPONENT = cls  # type: ignore[attr-defined]
-    return cls
 
 
 def _defaultdict_of_set() -> defaultdict[_T1, set[_T2]]:  # Migrate from <=3.4

--- a/tcod/ecs/__init__.py
+++ b/tcod/ecs/__init__.py
@@ -6,12 +6,14 @@ import warnings
 from collections import defaultdict
 from typing import TypeVar
 
+from tcod.ecs.constants import IsA
 from tcod.ecs.entity import Entity
 from tcod.ecs.world import World
 
 __all__ = (
     "__version__",
     "Entity",
+    "IsA",
     "World",
     "abstract_component",
 )

--- a/tcod/ecs/constants.py
+++ b/tcod/ecs/constants.py
@@ -1,0 +1,7 @@
+"""Special constants and sentinel values."""
+from typing import Final
+
+from sentinel_value import sentinel
+
+IsA: Final = sentinel("IsA")
+"""The default is-a relationship tag used for entity inheritance."""

--- a/tcod/ecs/entity.py
+++ b/tcod/ecs/entity.py
@@ -396,7 +396,7 @@ class EntityComponents(MutableMapping[Union[Type[Any], Tuple[object, Type[Any]]]
             FutureWarning,
             stacklevel=_stacklevel + 1,
         )
-        key = getattr(value, "_TCOD_BASE_COMPONENT", value.__class__)
+        key = value.__class__
         self[key] = value
 
     @staticmethod
@@ -404,9 +404,6 @@ class EntityComponents(MutableMapping[Union[Type[Any], Tuple[object, Type[Any]]]
         """Verify that abstract classes are accessed correctly."""
         if isinstance(key, tuple):
             key = key[1]
-        assert (
-            getattr(key, "_TCOD_BASE_COMPONENT", key) is key
-        ), "Abstract components must be accessed via the base class."
         return True
 
     def __getitem__(self, key: ComponentKey[T]) -> T:

--- a/tcod/ecs/query.py
+++ b/tcod/ecs/query.py
@@ -342,7 +342,7 @@ class WorldQuery:
         """Convert parameters into queries."""
         traverse = tuple(traverse)
         yield from (_QueryTraversalPropagation(_QueryComponent(component), traverse, depth) for component in components)
-        yield from (_QueryTag(tag) for tag in tags)
+        yield from (_QueryTraversalPropagation(_QueryTag(tag), traverse, depth) for tag in tags)
         yield from (_QueryRelation(relations) for relations in relations)
 
     def all_of(  # noqa: PLR0913

--- a/tcod/ecs/query.py
+++ b/tcod/ecs/query.py
@@ -343,7 +343,7 @@ class WorldQuery:
         traverse = tuple(traverse)
         yield from (_QueryTraversalPropagation(_QueryComponent(component), traverse, depth) for component in components)
         yield from (_QueryTraversalPropagation(_QueryTag(tag), traverse, depth) for tag in tags)
-        yield from (_QueryRelation(relations) for relations in relations)
+        yield from (_QueryTraversalPropagation(_QueryRelation(relations), traverse, depth) for relations in relations)
 
     def all_of(  # noqa: PLR0913
         self,

--- a/tcod/ecs/query.py
+++ b/tcod/ecs/query.py
@@ -244,6 +244,8 @@ class _QueryLogicalAnd:
             cache.dependencies[dependency].add((world, self))
 
     def _compile(self, world: World, cache: _QueryCache) -> Set[Entity]:
+        if len(self._all_of) == 1 and not self._none_of:  # Only one sub-query, simply return the results of it
+            return _get_query(world, next(iter(self._all_of)))  # Avoids an extra copy of a set
         requires = sorted(  # Place the smallest sets first to speed up intersections
             (_get_query(world, q) for q in self._all_of), key=len
         )
@@ -271,6 +273,8 @@ class _QueryLogicalOr:
             cache.dependencies[dependency].add((world, self))
 
     def _compile(self, world: World, cache: _QueryCache) -> Set[Entity]:
+        if len(self._any_of) == 1:  # If there is only one sub-query then simply return the results of it
+            return _get_query(world, next(iter(self._any_of)))  # Avoids an extra copy of a set
         entities: set[Entity] = set()
         entities.update(*(_get_query(world, q) for q in self._any_of))
         return entities

--- a/tests/test_relations.py
+++ b/tests/test_relations.py
@@ -50,6 +50,10 @@ def test_relations_many() -> None:
 
     with pytest.raises(KeyError):
         entity_a.relation_tag["foo"]
+    with pytest.raises(KeyError):
+        entity_a.relation_tags_many["foo"].remove(entity_a)
+    assert entity_a not in entity_a.relation_tags_many["foo"]
+
     entity_a.relation_tags_many["foo"] = (entity_b, entity_c)
     with pytest.raises(ValueError, match=r"Entity relation has multiple targets but an exclusive value was expected\."):
         entity_a.relation_tag["foo"]
@@ -59,6 +63,9 @@ def test_relation_components() -> None:
     world = tcod.ecs.World()
     entity_a = world["A"]
     entity_b = world["B"]
+
+    with pytest.raises(KeyError):
+        entity_b.relation_components[int][entity_a]
 
     entity_b.relation_components[int][entity_a] = 1
     assert entity_b.relation_components[int][entity_a] == 1

--- a/tests/test_traversal.py
+++ b/tests/test_traversal.py
@@ -1,0 +1,65 @@
+"""Inheritance tests."""
+
+import pytest
+
+from tcod.ecs import IsA, World
+
+# ruff: noqa: D103
+
+
+def test_component_traversal() -> None:
+    world = World()
+    world["derived"].relation_tag[IsA] = world["base"]
+    world["instance"].relation_tag[IsA] = world["derived"]
+    world["base"].components[str] = "base"
+    assert world["base"].components[str] == "base"
+    assert world["derived"].components[str] == "base"  # Inherit from direct parent
+    assert world["instance"].components[str] == "base"  # Inherit from parents parent
+
+    world["derived"].components[str] = "derived"
+    assert world["base"].components[str] == "base"
+    assert world["derived"].components[str] == "derived"  # Now has its own value
+    assert world["instance"].components[str] == "derived"  # Inherited value changed to parent
+
+    world["instance"].components[str] = "instance"
+    assert world["base"].components[str] == "base"
+    assert world["derived"].components[str] == "derived"
+    assert world["instance"].components[str] == "instance"
+
+    del world["derived"].components[str]
+    assert world["base"].components[str] == "base"
+    assert world["derived"].components[str] == "base"  # Direct value should be deleted
+    assert world["instance"].components[str] == "instance"
+
+    del world["base"].components[str]
+    with pytest.raises(KeyError, match="str"):
+        assert world["base"].components[str]
+    with pytest.raises(KeyError, match="str"):
+        assert world["derived"].components[str]
+    assert str not in world["base"].components
+    assert str not in world["derived"].components
+    assert world["instance"].components[str] == "instance"
+
+    del world["instance"].components[str]
+    assert str not in world["base"].components
+    assert str not in world["derived"].components
+    assert str not in world["instance"].components
+
+
+def test_component_traversal_alternate() -> None:
+    world = World()
+    world["base"].components[str] = "base"
+    world["alt"].components[str] = "alt"
+    world["derived"].relation_tag[IsA] = world["base"]
+    world["derived"].relation_tag["alt"] = world["alt"]
+    assert world["derived"].components[str] == "base"
+    assert world["derived"].components(traverse="alt")[str] == "alt"
+    with pytest.raises(KeyError, match="str"):
+        assert world["derived"].components(traverse=None)[str]
+
+    assert str in world["derived"].components
+    assert str in world["derived"].components(traverse="alt")
+    assert str not in world["derived"].components(traverse=None)
+    assert set(world["derived"].components.keys()) == {str}
+    assert set(world["derived"].components(traverse="alt").keys()) == {str}
+    assert not set(world["derived"].components(traverse=None).keys())

--- a/tests/test_traversal.py
+++ b/tests/test_traversal.py
@@ -1,4 +1,5 @@
 """Inheritance tests."""
+from typing import Final
 
 import pytest
 
@@ -59,21 +60,67 @@ def test_component_traversal_alternate() -> None:
     world["derived"].relation_tag[IsA] = world["base"]
     world["derived"].relation_tag["alt"] = world["alt"]
     assert world["derived"].components[str] == "base"
-    assert world["derived"].components(traverse="alt")[str] == "alt"
+    assert world["derived"].components(traverse=["alt"])[str] == "alt"
     with pytest.raises(KeyError, match="str"):
-        assert world["derived"].components(traverse=None)[str]
+        assert world["derived"].components(traverse=())[str]
 
     assert str in world["derived"].components
-    assert str in world["derived"].components(traverse="alt")
-    assert str not in world["derived"].components(traverse=None)
+    assert str in world["derived"].components(traverse=["alt"])
+    assert str not in world["derived"].components(traverse=())
     assert set(world["derived"].components.keys()) == {str}
-    assert set(world["derived"].components(traverse="alt").keys()) == {str}
-    assert not set(world["derived"].components(traverse=None).keys())
+    assert set(world["derived"].components(traverse=["alt"]).keys()) == {str}
+    assert not set(world["derived"].components(traverse=()).keys())
 
     assert world.Q.all_of(components=[str]).get_entities() == {world["base"], world["alt"], world["derived"]}
-    assert world.Q.all_of(components=[str], traverse="alt").get_entities() == {
+    assert world.Q.all_of(components=[str], traverse=["alt"]).get_entities() == {
         world["base"],
         world["alt"],
         world["derived"],
     }
     assert world.Q.all_of(components=[str], depth=0).get_entities() == {world["base"], world["alt"]}
+
+
+def test_multiple_inheritance() -> None:
+    world = World()
+    ViaA: Final = object()
+    ViaC: Final = object()
+    world["A"].components[str] = "A"
+    world["B"].components[str] = "B"
+    world["B"].components[int] = 0
+    world["C"].components[str] = "C"
+    world["C"].relation_tag[IsA] = world["B"]
+    world["D"].relation_tag[ViaA] = world["A"]
+    world["D"].relation_tag[ViaC] = world["C"]
+    world["E"].relation_tag[IsA] = world["D"]
+    assert str not in world["D"].components
+    assert int not in world["D"].components
+    assert world["E"].components(traverse=[ViaA, IsA])[str] == "A"
+    assert world["E"].components(traverse=[ViaA, ViaC, IsA])[str] == "A"
+    assert world["E"].components(traverse=[ViaC, ViaA, IsA])[str] == "C"
+    assert world["E"].components(traverse=[IsA, ViaA, ViaC])[int] == 0
+    assert world["E"].components(traverse=[IsA, ViaA, ViaC]).keys() == {str, int}
+    assert world["E"].components(traverse=[IsA, ViaA]).keys() == {str}
+    assert world.Q.all_of(components=[int]).get_entities() == {world["B"], world["C"]}
+    assert world.Q.all_of(components=[int], traverse=[IsA, ViaC]).get_entities() == {
+        world["B"],
+        world["C"],
+        world["D"],
+        world["E"],
+    }
+
+
+def test_cyclic_inheritance() -> None:
+    world = World()
+    world["A"].relation_tag[IsA] = world["D"]
+    world["B"].relation_tag[IsA] = world["A"]
+    world["C"].relation_tag[IsA] = world["B"]
+    world["D"].relation_tag[IsA] = world["C"]
+
+    world["A"].components[str] = "A"
+    world["C"].components[str] = "C"
+
+    assert int not in world["A"].components
+    assert world["A"].components[str] == "A"
+    assert world["B"].components[str] == "A"
+    assert world["C"].components[str] == "C"
+    assert world["D"].components[str] == "C"


### PR DESCRIPTION
Adds support for inheritance and prefabs, Closes #12 

Hard parts are already done. I need to clean up repeatable code, integrate it, and write tests.

- [x] Query propagation
- [x] Components via traversal
- [x] Tags via traversal
- [x] Relations via traversal
- [x] Entity instantiation
- [ ] Readme examples

Traversal (inheritance) currently supports cyclic inheritance and multiple inheritance.

Some features may lower performance.  I'll try to note this in the changelog.